### PR TITLE
feat: refactor date sep

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -103,12 +103,16 @@ exports.YYYYMMDDHHmmss = function (d, options) {
 
   var dateSep = '-';
   var timeSep = ':';
+  var sep = ' ';
   if (options) {
-    if (options.dateSep) {
+    if (typeof options.dateSep !== 'undefined') {
       dateSep = options.dateSep;
     }
-    if (options.timeSep) {
+    if (typeof options.timeSep !== 'undefined') {
       timeSep = options.timeSep;
+    }
+    if (typeof options.sep !== 'undefined') {
+      sep = options.sep;
     }
   }
   var date = d.getDate();
@@ -131,7 +135,7 @@ exports.YYYYMMDDHHmmss = function (d, options) {
   if (seconds < 10) {
     seconds = '0' + seconds;
   }
-  return d.getFullYear() + dateSep + month + dateSep + date + ' ' +
+  return d.getFullYear() + dateSep + month + dateSep + date + sep +
     hours + timeSep + mintues + timeSep + seconds;
 };
 

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -32,6 +32,12 @@ test('YYYYMMDDHHmmss() should work with custom sep', t => {
   t.is(utils.YYYYMMDDHHmmss(date, {
     timeSep: ';'
   }), '2014-02-14 01;02;03');
+
+  t.is(utils.YYYYMMDDHHmmss(date, {
+    sep: '',
+    timeSep: '',
+    dateSep: ''
+  }), '20140214010203');
 });
 
 test('YYYYMMDDHHmmss() should work with time string', t => {


### PR DESCRIPTION
支持 '' 这类的分隔符

```
utils.YYYYMMDDHHmmss(new Date(), {
    sep: '',
    timeSep: '',
    dateSep: ''
});
```

20171216092219