### PR TITLE
fix dig bug

### DIFF
--- a/lib/optimize.js
+++ b/lib/optimize.js
@@ -41,7 +41,7 @@ exports.dig = function (obj) {
   var value = obj[arguments[1]];
   for (var i = 2; i < arguments.length; i++) {
     if (!value) {
-      break;
+      throw new Error('param %s not find!', i);
     }
     value = value[arguments[i]];
   }


### PR DESCRIPTION
如果 dig 的对象外层有所改变导致内层无法找到的话，之前的返回值可能会让人迷惑，不如直接抛出异常