### PR TITLE
fixed: getParamNames bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - '8'
   - '10'
 install:
-  - npm i --global
+  - npm install --global npminstall && npminstall
 script:
   - 'npm run ci'
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - '8'
   - '10'
 install:
-  - npm i
+  - npm i --global
 script:
   - 'npm run ci'
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - '8'
   - '10'
 install:
-  - npm i npminstall && npminstall
+  - npm i
 script:
   - 'npm run ci'
 after_script:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ utils.has({hello: 'world'}, 'hello'); //true
 
 // empty function
 utils.noop = function () {}
+
+// throw out an assertion error if you were given an invalid "func"
+try {
+  utils.getParamNames(null/* any non-function */); // Only function is allowed
+} catch (err) {
+  console.error(err); // Assertion Error
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ utils.noop = function () {}
 
 // throw out an assertion error if you were given an invalid "func"
 try {
-  utils.getParamNames(null/* any non-function */); // Only function is allowed
+  utils.getParamNames(null); // Only function is allowed
 } catch (err) {
   console.error(err); // Assertion Error
 }

--- a/lib/function.js
+++ b/lib/function.js
@@ -16,6 +16,9 @@ exports.noop = function noop() {};
  * @return {Array} names
  */
 exports.getParamNames = function getParamNames(func, cache) {
+  if (typeof func !== 'function') {
+    return [];
+  }
   cache = cache !== false;
   if (cache && func.__cache_names) {
     return func.__cache_names;

--- a/lib/function.js
+++ b/lib/function.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assert = require('assert');
+
 /**
  * A empty function.
  *
@@ -16,9 +18,9 @@ exports.noop = function noop() {};
  * @return {Array} names
  */
 exports.getParamNames = function getParamNames(func, cache) {
-  if (typeof func !== 'function') {
-    return [];
-  }
+  var type = typeof func;
+  assert(type === 'function', `The "func" must be a function. Received type "${type}"`);
+
   cache = cache !== false;
   if (cache && func.__cache_names) {
     return func.__cache_names;

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -4,8 +4,18 @@ import test from 'ava';
 import utils from '../';
 
 test('getParamNames() should return parameter names', t => {
-  t.deepEqual(utils.getParamNames(null), []);
-  t.deepEqual(utils.getParamNames(undefined), []);
+  try {
+    utils.getParamNames(null);  
+  } catch (err) {
+    t.is(err.message, 'The "func" must be a function. Received type "object"')
+  }
+  
+  try {
+    utils.getParamNames(undefined);  
+  } catch (err) {
+    t.is(err.message, 'The "func" must be a function. Received type "undefined"')
+  }
+  
   t.deepEqual(utils.getParamNames(function () {}), []);
   /* jshint ignore:start */
   t.deepEqual(utils.getParamNames(function (key1) {}), ['key1']);

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -4,18 +4,8 @@ import test from 'ava';
 import utils from '../';
 
 test('getParamNames() should return parameter names', t => {
-  try {
-    utils.getParamNames(null);  
-  } catch (err) {
-    t.is(err.message, 'The "func" must be a function. Received type "object"')
-  }
-  
-  try {
-    utils.getParamNames(undefined);  
-  } catch (err) {
-    t.is(err.message, 'The "func" must be a function. Received type "undefined"')
-  }
-  
+  t.throws(() => utility.getParamNames(null));
+  t.throws(() => utility.getParamNames(undefined));
   t.deepEqual(utils.getParamNames(function () {}), []);
   /* jshint ignore:start */
   t.deepEqual(utils.getParamNames(function (key1) {}), ['key1']);

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -4,6 +4,8 @@ import test from 'ava';
 import utils from '../';
 
 test('getParamNames() should return parameter names', t => {
+  t.deepEqual(utils.getParamNames(null), []);
+  t.deepEqual(utils.getParamNames(undefined), []);
   t.deepEqual(utils.getParamNames(function () {}), []);
   /* jshint ignore:start */
   t.deepEqual(utils.getParamNames(function (key1) {}), ['key1']);

--- a/test_ts/function.test.ts
+++ b/test_ts/function.test.ts
@@ -4,6 +4,8 @@ import * as utility from '../';
 
 
 test('getParamNames() should return parameter names', t => {
+  t.deepEqual(utility.getParamNames(undefined), []);
+  t.deepEqual(utility.getParamNames(null), []);
   t.deepEqual(utility.getParamNames(function () {}), []);
   /* jshint ignore:start */
   t.deepEqual(utility.getParamNames(function (key1) {}), ['key1']);

--- a/test_ts/function.test.ts
+++ b/test_ts/function.test.ts
@@ -4,16 +4,8 @@ import * as utility from '../';
 
 
 test('getParamNames() should return parameter names', t => {
-  try {
-    utility.getParamNames(null);  
-  } catch (err) {
-    t.is(err.message, 'The "func" must be a function. Received type "object"')
-  }
-  try {
-    utility.getParamNames(undefined);  
-  } catch (err) {
-    t.is(err.message, 'The "func" must be a function. Received type "undefined"')
-  }
+  t.throws(() => utility.getParamNames(null));
+  t.throws(() => utility.getParamNames(undefined));
   t.deepEqual(utility.getParamNames(function () {}), []);
   /* jshint ignore:start */
   t.deepEqual(utility.getParamNames(function (key1) {}), ['key1']);

--- a/test_ts/function.test.ts
+++ b/test_ts/function.test.ts
@@ -4,8 +4,16 @@ import * as utility from '../';
 
 
 test('getParamNames() should return parameter names', t => {
-  t.deepEqual(utility.getParamNames(undefined), []);
-  t.deepEqual(utility.getParamNames(null), []);
+  try {
+    utility.getParamNames(null);  
+  } catch (err) {
+    t.is(err.message, 'The "func" must be a function. Received type "object"')
+  }
+  try {
+    utility.getParamNames(undefined);  
+  } catch (err) {
+    t.is(err.message, 'The "func" must be a function. Received type "undefined"')
+  }
   t.deepEqual(utility.getParamNames(function () {}), []);
   /* jshint ignore:start */
   t.deepEqual(utility.getParamNames(function (key1) {}), ['key1']);


### PR DESCRIPTION
* fixed: The `getParamNames` will get crash with an incorrect value of `func`.  Such as: `null | undefined` etc.

* added: test case in `function.test` and  76 passed