### PR TITLE
fix: do not use ECMAScript6 syntax.

### DIFF
--- a/lib/function.js
+++ b/lib/function.js
@@ -19,7 +19,7 @@ exports.noop = function noop() {};
  */
 exports.getParamNames = function getParamNames(func, cache) {
   var type = typeof func;
-  assert(type === 'function', 'The "func" must be a function. Received type "${type}"');
+  assert(type === 'function', 'The "func" must be a function. Received type "' + type + '"');
 
   cache = cache !== false;
   if (cache && func.__cache_names) {

--- a/lib/function.js
+++ b/lib/function.js
@@ -19,7 +19,7 @@ exports.noop = function noop() {};
  */
 exports.getParamNames = function getParamNames(func, cache) {
   var type = typeof func;
-  assert(type === 'function', `The "func" must be a function. Received type "${type}"`);
+  assert(type === 'function', 'The "func" must be a function. Received type "${type}"');
 
   cache = cache !== false;
   if (cache && func.__cache_names) {


### PR DESCRIPTION
There are some client libraries that depends on this library, since it would not be transpiled by default, we would get compatibility issues on production.