### PR TITLE
feat: hash 参数支持 object 类型

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,53 +61,53 @@ declare namespace utility {
    * hash
    *
    * @param {String} method hash method, e.g.: 'md5', 'sha1'
-   * @param {String|Buffer} s
+   * @param {String|Buffer|Object} s
    * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
    * @return {String} md5 hash string
    * @public
    */
   function hash(
     method: 'md5' | 'sha1',
-    s: string | Buffer,
+    s: string | Buffer | Object,
     format?: 'hex' | 'base64',
   ): string;
 
   /**
    * md5 hash
    *
-   * @param {String|Buffer} s
+   * @param {String|Buffer|Object} s
    * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
    * @return {String} md5 hash string
    * @public
    */
   function md5(
-    s: string | Buffer,
+    s: string | Buffer | Object,
     format?: 'hex' | 'base64',
   ): string;
 
   /**
    * sha1 hash
    *
-   * @param {String|Buffer} s
+   * @param {String|Buffer|Object} s
    * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
    * @return {String} sha1 hash string
    * @public
    */
   function sha1(
-    s: string | Buffer,
+    s: string | Buffer | Object,
     format?: 'hex' | 'base64',
   ): string;
 
   /**
    * sha256 hash
    *
-   * @param {String|Buffer} s
+   * @param {String|Buffer|Object} s
    * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
    * @return {String} sha256 hash string
    * @public
    */
   function sha256(
-    s: string | Buffer,
+    s: string | Buffer | Object,
     format?: 'hex' | 'base64',
   ): string;
 

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -6,7 +6,7 @@ var crypto = require('crypto');
  * hash
  *
  * @param {String} method hash method, e.g.: 'md5', 'sha1'
- * @param {String|Buffer} s
+ * @param {String|Buffer|Object} s
  * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
  * @return {String} md5 hash string
  * @public
@@ -24,7 +24,7 @@ exports.hash = function hash(method, s, format) {
 /**
  * md5 hash
  *
- * @param {String|Buffer} s
+ * @param {String|Buffer|Object} s
  * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
  * @return {String} md5 hash string
  * @public
@@ -36,7 +36,7 @@ exports.md5 = function md5(s, format) {
 /**
  * sha1 hash
  *
- * @param {String|Buffer} s
+ * @param {String|Buffer|Object} s
  * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
  * @return {String} sha1 hash string
  * @public
@@ -48,7 +48,7 @@ exports.sha1 = function sha1(s, format) {
 /**
  * sha256 hash
  *
- * @param {String|Buffer} s
+ * @param {String|Buffer|Object} s
  * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
  * @return {String} sha256 hash string
  * @public

--- a/test_ts/crypto.test.ts
+++ b/test_ts/crypto.test.ts
@@ -13,11 +13,9 @@ test('md5() should return md5 string', (t)=> {
   t.is(utility.md5('', 'base64'), '1B2M2Y8AsgTpgAmY7PhCfg==');
 
 
-  // !!! TS: ERROR
-/*
   t.is(utility.md5({foo: 'bar', bar: 'foo'}), '63a9d72936c6f7366fa5e72fa0cac8b4');
   t.is(utility.md5({foo: 'bar', bar: 'foo'}), utility.md5({bar: 'foo', foo: 'bar'}));
   t.is(utility.md5({foo: 'bar', bar: 'foo', v: [1, 2, 3]}), utility.md5({v: [1, 2, 3], bar: 'foo', foo: 'bar'}));
   t.is(utility.md5({foo: 'bar', bar: 'foo', args: {age: 1, name: 'foo'}, args2: {haha:'哈哈', bi: 'boo'}, v: [1, 2, 3]}),
-    utility.md5({v: [1, 2, 3], bar: 'foo', foo: 'bar', args2: {bi: 'boo', haha:'哈哈'}, args: {name: 'foo', age: 1}})); */
+    utility.md5({v: [1, 2, 3], bar: 'foo', foo: 'bar', args2: {bi: 'boo', haha:'哈哈'}, args: {name: 'foo', age: 1}}));
 });


### PR DESCRIPTION
```js
/**
 * hash
 *
 * @param {String} method hash method, e.g.: 'md5', 'sha1'
 * @param {String|Buffer|Object} s
 * @param {String} [format] output string format, could be 'hex' or 'base64'. default is 'hex'.
 * @return {String} md5 hash string
 * @public
 */
exports.hash = function hash(method, s, format) {
  var sum = crypto.createHash(method);
  var isBuffer = Buffer.isBuffer(s);
  if (!isBuffer && typeof s === 'object') {
    s = JSON.stringify(sortObject(s));
  }
  sum.update(s, isBuffer ? 'binary' : 'utf8');
  return sum.digest(format || 'hex');
};
```
`hash`方法是支持`Object`类型入参，但 TS 类型不支持